### PR TITLE
add phantomjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "devDependencies": {
     "ampersand-view": "^7.0.1",
     "browserify": "^5.10.1",
+    "phantomjs": "^1.9.7-15",
     "precommit-hook": "0.x.x",
     "run-browser": "",
     "tap-spec": "^0.2.0",


### PR DESCRIPTION
Required as a dev dependency so tests will run if it is not installed globally.
