### PR TITLE
invoke callback for async hide.

### DIFF
--- a/ampersand-view-switcher.js
+++ b/ampersand-view-switcher.js
@@ -103,6 +103,7 @@ ViewSwitcher.prototype._hide = function (view, cb) {
         if (customHide.length === 3) {
             customHide(view, this.current, function () {
                 view.remove();
+                if (cb) cb();
             });
         } else {
             customHide(view, this.current);


### PR DESCRIPTION
When using the async version of `hide`, the next view is never shown. This is because `cb` is never called.
This PR fixes the issue.
