### PR TITLE
Resolve bug: ending up with 2 views in the container

### DIFF
--- a/ampersand-view-switcher.js
+++ b/ampersand-view-switcher.js
@@ -31,8 +31,12 @@ ViewSwitcher.prototype.set = function (view) {
     }
 
     if (this.config.waitForRemove) {
+        this.next = view;
         this._hide(prev, function () {
-            self._show(view);
+            if(self.next===view){
+                self.next = null;
+                self._show(view);
+            }
         });
     } else {
         this._hide(prev);

--- a/ampersand-view-switcher.js
+++ b/ampersand-view-switcher.js
@@ -33,8 +33,8 @@ ViewSwitcher.prototype.set = function (view) {
     if (this.config.waitForRemove) {
         this.next = view;
         this._hide(prev, function () {
-            if(self.next===view){
-                self.next = null;
+            if (self.next === view) {
+                delete self.next;
                 self._show(view);
             }
         });


### PR DESCRIPTION
# Bug
Sometimes 2 views were displayed at the same time using the waitForRemove option with a custom hide function calling the removed callback async 

# Changes
store new view waiting for previous view to be removed in case set method is called during this interval