### PR TITLE
Append method

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -10,6 +10,7 @@
     "indent": 4,
     "predef": [
         "$",
+        "document",
         "FormBot",
         "socket",
         "confirm",

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ module.exports = AmpersandView.extend({
                 app.currentPage = view;
             }
         });
-    } 
+    }
 });
 ```
 
@@ -77,7 +77,7 @@ this.pageSwitcher = new ViewSwitcher(this.pageContainer, {
     // here we provide a few things to do before the element gets
     // removed from the DOM.
     hide: function (oldView, cb) {
-        // it's inserted and rendered for me so we'll add a class 
+        // it's inserted and rendered for me so we'll add a class
         // that has a corresponding CSS transition.
         oldView.el.classList.add('animateOut');
         // give it time to finish (yes there are other ways to do this)
@@ -108,6 +108,7 @@ this.pageSwitcher = new ViewSwitcher(this.pageContainer, {
     * `show` {Function} [optional] A function that gets called when a view is being shown. It's passed the new view.
     * `hide` {Function} [optional] A function that gets called when a view is being removed. It's passed the old view and a callback. If you name 2 incoming arguments for example `function (oldView, callback) { ... }` the view switcher will wait for you to call the callback before it's considered ready. If you only use one like this: `function (oldView) { ... }` it won't wait for you to call a callback.
     * `waitForRemove` {Boolean} [default: `false`] Whether or not to wait until your `hide` animation callback gets called before starting your `show` animation.
+    * `prepend` {Boolean} [default: `false`] Whether or not to prepend the view to the `element`.
     * `empty` {Function} [optional] A function that gets called any time the view switcher is empty. Including when you instantiate it without giving it a view to start with.
     * `view` {View} [optional] A view instance to start with.
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ this.pageSwitcher = new ViewSwitcher(this.pageContainer, {
     * `show` {Function} [optional] A function that gets called when a view is being shown. It's passed the new view.
     * `hide` {Function} [optional] A function that gets called when a view is being removed. It's passed the old view and a callback. If you name 2 incoming arguments for example `function (oldView, callback) { ... }` the view switcher will wait for you to call the callback before it's considered ready. If you only use one like this: `function (oldView) { ... }` it won't wait for you to call a callback.
     * `waitForRemove` {Boolean} [default: `false`] Whether or not to wait until your `hide` animation callback gets called before starting your `show` animation.
-    * `prepend` {Boolean} [default: `false`] Whether or not to prepend the view to the `element`.
+    * `prepend` {Boolean} [default: `false`] Whether or not to prepend the view to the `element`. When this is `false`, the view is appended.
     * `empty` {Function} [optional] A function that gets called any time the view switcher is empty. Including when you instantiate it without giving it a view to start with.
     * `view` {View} [optional] A view instance to start with.
 

--- a/ampersand-view-switcher.js
+++ b/ampersand-view-switcher.js
@@ -6,6 +6,7 @@ function ViewSwitcher(el, options) {
         hide: null,
         show: null,
         empty: null,
+        prepend: false,
         waitForRemove: false
     };
     for (var item in options) {
@@ -82,7 +83,13 @@ ViewSwitcher.prototype._onViewRemove = function (view) {
 
 ViewSwitcher.prototype._render = function (view) {
     if (!view.rendered) view.render({containerEl: this.el});
-    if (!view.insertSelf) this.el.appendChild(view.el);
+    if (!view.insertSelf) {
+        if (this.config.prepend) {
+            this.el.insertBefore(view.el, this.el.firstChild);
+        } else {
+            this.el.appendChild(view.el);
+        }
+    }
 };
 
 ViewSwitcher.prototype._hide = function (view, cb) {

--- a/test/main.js
+++ b/test/main.js
@@ -79,6 +79,17 @@ test('`options.show`', function (t) {
     t.end();
 });
 
+test('`options.prepend`', function (t) {
+    var TestView = makeTestView({
+        prepend: true
+    });
+    var base = new TestView();
+    var c1 = new ItemView();
+    base.el.appendChild(document.createElement('div'));
+    base.switcher.set(c1);
+    t.equal(c1.el.parentNode.firstChild, c1.el, 'view was prepended to container');
+    t.end();
+});
 
 test('`options.hide`', function (t) {
     var TestView = makeTestView({


### PR DESCRIPTION
View-switcher is great to handle modal dialogs.

To be able to use advanced animation, i need the view prepended instead of appended to the `body` so i can use sibling selectors like `+` or  `~` to siblings following the view.

This is why i added a `prepend` boolean option, which defaults to `false`, adjusted the docs and wrote a unit test to check if the views `el` is really prepended.