### PR TITLE
Update deps to survive get-object-path@^0.0.2 being removed from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "ampersand-version": "^1.0.0"
   },
   "devDependencies": {
-    "ampersand-view": "^7.0.1",
-    "browserify": "^6.2.0",
+    "ampersand-view": "^9.0.2",
+    "browserify": "^13.0.0",
     "jshint": "^2.9.1",
-    "phantomjs": "^1.9.12",
+    "phantomjs-prebuilt": "^2.1.3",
     "precommit-hook": "^3.0.0",
     "tape": "^4.4.0",
     "zuul": "^3.9.0"


### PR DESCRIPTION
Similar to AmpersandJS/ampersand-form-view#61
