### PR TITLE
Bind `_onViewRemove` to view switcher instance

### DIFF
--- a/ampersand-view-switcher.js
+++ b/ampersand-view-switcher.js
@@ -72,7 +72,7 @@ ViewSwitcher.prototype._show = function (view) {
 };
 
 ViewSwitcher.prototype._registerRemoveListener = function (view) {
-    if (view) view.once('remove', this._onViewRemove, this);
+    if (view) view.once('remove', this._onViewRemove.bind(this));
 };
 
 ViewSwitcher.prototype._onViewRemove = function (view) {


### PR DESCRIPTION
`once` no longer accepts a final context argument for `this`, so it must be explicitly `bind`ed

Closes #35