### PR TITLE
Conform view-switcher to view conventions so that it can be used as subview.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ module.exports = AmpersandView.extend({
         this.pageContainer = this.queryByHook('page-container');
 
         // set up our page switcher for that element
-        this.pageSwitcher = new ViewSwitcher(this.pageContainer, {
+        this.pageSwitcher = new ViewSwitcher({
+            el: this.pageContainer, 
             // here we provide a few things we'd like to do each time
             // we switch pages in the app.
             show: function (view) {
@@ -71,7 +72,8 @@ Or if you wanted to animate them you can do it asynchronously like so:
 
 ```js
 // set up our page switcher for that element
-this.pageSwitcher = new ViewSwitcher(this.pageContainer, {
+this.pageSwitcher = new ViewSwitcher({
+    el: this.pageContainer,
     // whether or not to wait for remove to be done before starting show
     waitForRemove: true,
     // here we provide a few things to do before the element gets
@@ -101,10 +103,10 @@ this.pageSwitcher = new ViewSwitcher(this.pageContainer, {
 
 ## API Reference
 
-### constructor `new ViewSwitcher(element, [options])`
+### constructor `new ViewSwitcher([options])`
 
-* `element` {Element} The DOM element that should contain the views.
-* `options` {Object} [optinal]
+* `options` {Object} [optional]
+    * `element` {Element} The DOM element that should contain the views.
     * `show` {Function} [optional] A function that gets called when a view is being shown. It's passed the new view.
     * `hide` {Function} [optional] A function that gets called when a view is being removed. It's passed the old view and a callback. If you name 2 incoming arguments for example `function (oldView, callback) { ... }` the view switcher will wait for you to call the callback before it's considered ready. If you only use one like this: `function (oldView) { ... }` it won't wait for you to call a callback.
     * `waitForRemove` {Boolean} [default: `false`] Whether or not to wait until your `hide` animation callback gets called before starting your `show` animation.
@@ -129,7 +131,7 @@ The instantiated view switcher has this one main method. Simply call it with the
 This is most likely going to be an instantiated [ampersand-view](https://github.com/ampersandjs/ampersand-view) or Backbone.View, but can be anything that has a `.el` property that represents that view's root element and `.remove()` method that cleans up after itself. In addition if your custom view object has a `.render()` method it will get called before the view is added to the DOM.
 
 ```javascript
-var switcher = new ViewSwitcher(document.querySelector('#pageContainer'));
+var switcher = new ViewSwitcher({el: document.querySelector('#pageContainer')});
 
 var view = new MyView({ model: model });
 
@@ -143,7 +145,7 @@ switcher.set(view);
 Removes the current view from the view switcher. Calls `callback` when done if one was provided.`
 
 ```javascript
-var switcher = new ViewSwitcher(document.querySelector('#pageContainer'));
+var switcher = new ViewSwitcher({el: document.querySelector('#pageContainer')});
 
 var view = new MyView({ model: model });
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ this.pageSwitcher = new ViewSwitcher({
 ### constructor `new ViewSwitcher([options])`
 
 * `options` {Object} [optional]
-    * `element` {Element} The DOM element that should contain the views.
+    * `el` {Element} The DOM element that should contain the views.
     * `show` {Function} [optional] A function that gets called when a view is being shown. It's passed the new view.
     * `hide` {Function} [optional] A function that gets called when a view is being removed. It's passed the old view and a callback. If you name 2 incoming arguments for example `function (oldView, callback) { ... }` the view switcher will wait for you to call the callback before it's considered ready. If you only use one like this: `function (oldView) { ... }` it won't wait for you to call a callback.
     * `waitForRemove` {Boolean} [default: `false`] Whether or not to wait until your `hide` animation callback gets called before starting your `show` animation.

--- a/ampersand-view-switcher.js
+++ b/ampersand-view-switcher.js
@@ -7,20 +7,16 @@ function ViewSwitcher(el, options) {
         show: null,
         empty: null,
         prepend: false,
-        waitForRemove: false
+        waitForRemove: false,
+        autoRender: true
     };
     for (var item in options) {
         if (this.config.hasOwnProperty(item)) {
             this.config[item] = options[item];
         }
     }
-    if (options.view) {
-        this._setCurrent(options.view);
-        this._render(options.view);
-    } else {
-        // call this so the empty callback gets called
-        this._onViewRemove();
-    }
+    this._setCurrent(options.view);
+    if(this.config.autoRender) this.render();
 }
 
 ViewSwitcher.prototype.set = function (view) {
@@ -43,6 +39,7 @@ ViewSwitcher.prototype.set = function (view) {
         this._hide(prev);
         this._show(view);
     }
+    return this;
 };
 
 ViewSwitcher.prototype._setCurrent = function (view) {
@@ -57,11 +54,13 @@ ViewSwitcher.prototype._setCurrent = function (view) {
 
 ViewSwitcher.prototype.clear = function (cb) {
     this._hide(this.current, cb);
+    return this;
 };
 
 // If the view switcher itself is removed, remove its child to avoid memory leaks
 ViewSwitcher.prototype.remove = function () {
     if (this.current) this.current.remove();
+    return this;
 };
 
 ViewSwitcher.prototype._show = function (view) {
@@ -94,6 +93,15 @@ ViewSwitcher.prototype._render = function (view) {
             this.el.appendChild(view.el);
         }
     }
+};
+
+ViewSwitcher.prototype.render = function () {
+    if (this.current && !this._rendered) {
+        this._render(this.current);
+    }
+    //set rendered, el exists even if a current view was not inserted/appended
+    this._rendered = true;
+    return this;
 };
 
 ViewSwitcher.prototype._hide = function (view, cb) {

--- a/ampersand-view-switcher.js
+++ b/ampersand-view-switcher.js
@@ -1,7 +1,7 @@
 /*$AMPERSAND_VERSION*/
-function ViewSwitcher(el, options) {
+function ViewSwitcher(options) {
     options || (options = {});
-    this.el = el;
+    this.el = options.el;
     this.config = {
         hide: null,
         show: null,
@@ -15,8 +15,9 @@ function ViewSwitcher(el, options) {
             this.config[item] = options[item];
         }
     }
+    
     this._setCurrent(options.view);
-    if(this.config.autoRender) this.render();
+    if (this.config.autoRender) this.render();
 }
 
 ViewSwitcher.prototype.set = function (view) {
@@ -60,6 +61,8 @@ ViewSwitcher.prototype.clear = function (cb) {
 // If the view switcher itself is removed, remove its child to avoid memory leaks
 ViewSwitcher.prototype.remove = function () {
     if (this.current) this.current.remove();
+    if (this.previous) this.previous.remove();
+    if (this.el && this.el.parentNode) this.el.parentNode.removeChild(this.el);
     return this;
 };
 
@@ -71,7 +74,7 @@ ViewSwitcher.prototype._show = function (view) {
 };
 
 ViewSwitcher.prototype._registerRemoveListener = function (view) {
-    if (view) view.once('remove', this._onViewRemove, this);
+    if (view && view.once) view.once('remove', this._onViewRemove, this);
 };
 
 ViewSwitcher.prototype._onViewRemove = function (view) {
@@ -85,12 +88,14 @@ ViewSwitcher.prototype._onViewRemove = function (view) {
 };
 
 ViewSwitcher.prototype._render = function (view) {
-    if (!view.rendered) view.render({containerEl: this.el});
-    if (!view.insertSelf) {
-        if (this.config.prepend) {
-            this.el.insertBefore(view.el, this.el.firstChild);
-        } else {
-            this.el.appendChild(view.el);
+    if(this.el) {
+        if (!view.rendered) view.render({containerEl: this.el});
+        if (!view.insertSelf) {
+            if (this.config.prepend) {
+                this.el.insertBefore(view.el, this.el.firstChild);
+            } else {
+                this.el.appendChild(view.el);
+            }
         }
     }
 };

--- a/ampersand-view-switcher.js
+++ b/ampersand-view-switcher.js
@@ -88,14 +88,13 @@ ViewSwitcher.prototype._onViewRemove = function (view) {
 };
 
 ViewSwitcher.prototype._render = function (view) {
-    if(this.el) {
-        if (!view.rendered) view.render({containerEl: this.el});
-        if (!view.insertSelf) {
-            if (this.config.prepend) {
-                this.el.insertBefore(view.el, this.el.firstChild);
-            } else {
-                this.el.appendChild(view.el);
-            }
+    if (!this.el) return;
+    if (!view.rendered) view.render({containerEl: this.el});
+    if (!view.insertSelf) {
+        if (this.config.prepend) {
+            this.el.insertBefore(view.el, this.el.firstChild);
+        } else {
+            this.el.appendChild(view.el);
         }
     }
 };

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "ampersand-view": "^9.0.2",
+    "ampersand-view-conventions": "^1.1.8",
     "browserify": "^13.0.0",
     "jshint": "^2.9.1",
     "phantomjs-prebuilt": "^2.1.3",

--- a/test/main.js
+++ b/test/main.js
@@ -26,7 +26,7 @@ var SelfInsertingView = View.extend({
     render: function () {}
 });
 
-viewCompliance.view(test, ViewSwitcher, { view: new makeTestView()() });
+viewCompliance.view(test, ViewSwitcher, { el: document.createElement("div") });
 
 test('basics', function (t) {
     var Base = makeTestView();

--- a/test/main.js
+++ b/test/main.js
@@ -1,4 +1,5 @@
 var test = require('tape');
+var viewCompliance = require('ampersand-view-conventions');
 var ViewSwitcher = require('../ampersand-view-switcher');
 var View = require('ampersand-view');
 
@@ -9,7 +10,8 @@ var makeTestView = function(options) {
         autoRender: true,
         render: function () {
             this.renderWithTemplate();
-            this.switcher = new ViewSwitcher(this.queryByHook('container'), options);
+            if (!options.el) options.el = this.queryByHook('container');
+            this.switcher = new ViewSwitcher(options);
         }
     });
 };
@@ -23,6 +25,8 @@ var SelfInsertingView = View.extend({
     insertSelf: true,
     render: function () {}
 });
+
+viewCompliance.view(test, ViewSwitcher, { view: new makeTestView()() });
 
 test('basics', function (t) {
     var Base = makeTestView();
@@ -150,7 +154,7 @@ test('`option.show` and `option.hide` used together', function (t) {
     t.end();
 });
 
-test('`option.autoRender`', function (t) {
+test('`option.autoRender` false`', function (t) {
     var c1 = new ItemView();
     var TestView = makeTestView({
         autoRender: false,
@@ -159,7 +163,19 @@ test('`option.autoRender`', function (t) {
     var base = new TestView();
     t.equal(base.switcher.config.autoRender, false, 'autoRender set to false');
     t.equal(c1.el.parentNode, null, 'option view was not rendered');
-    base.render();
-    t.equal(base.el.firstChild, c1.el.parentNode, 'option view was rendered');
+    base.switcher.render();
+    t.equal(base.el.firstChild, c1.el, 'option view was rendered');
+    t.end();
+});
+
+test('`option.autoRender` true', function (t) {
+    var c1 = new ItemView();
+    var TestView = makeTestView({
+        autoRender: true,
+        view: c1
+    });
+    var base = new TestView();
+    t.equal(base.switcher.config.autoRender, true, 'autoRender set to true');
+    t.equal(base.switcher.el.firstChild, c1.el, 'option view was rendered');
     t.end();
 });

--- a/test/main.js
+++ b/test/main.js
@@ -149,3 +149,17 @@ test('`option.show` and `option.hide` used together', function (t) {
     t.equal(hideCount, 1, 'hide should be called only once, after first view has been set');
     t.end();
 });
+
+test('`option.autoRender`', function (t) {
+    var c1 = new ItemView();
+    var TestView = makeTestView({
+        autoRender: false,
+        view: c1
+    });
+    var base = new TestView();
+    t.equal(base.switcher.config.autoRender, false, 'autoRender set to false');
+    t.equal(c1.el.parentNode, null, 'option view was not rendered');
+    base.render();
+    t.equal(base.el.firstChild, c1.el.parentNode, 'option view was rendered');
+    t.end();
+});


### PR DESCRIPTION
Added render method and _rendered attribute so that render is only called once, otherwise subsequent calls to render would appended to the view multiple times.
Added an autoRender attribute to config that is set to true by default, this is opposite of ampersand-view but retains backwards compatibility.

I tried to make as few changes as possible to implement this.
